### PR TITLE
setup.py to allow installation in a requirements.txt file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,17 @@
+from distutils.core import setup
+
+setup(
+    name='weibo',
+    author='Liao Xuefeng',
+    author_email='askxuefeng@gmail.com',
+    version='1.04',
+    url='https://github.com/michaelliao/sinaweibopy',
+    package_dir={'': 'src'},
+    py_modules=[
+        'weibo',
+        ],
+    long_description=open('README').read(),
+    install_requires=[
+        'simplejson',
+        ],
+)


### PR DESCRIPTION
I'm working on a project where I'd like to include this library as a proper dependency instead of as a file living in a folder of my repository.

So I've just made a small setup.py to be able to install this library with `pip install git+git://github.com/michaelliao/sinaweibopy.git#egg=weibo` in the future.

Maybe you'd also consider adding this package to PyPi? http://guide.python-distribute.org/creation.html#creating-your-distribution-file

/Björn
