### PR TITLE
在把body体转成json格式的时候没有错误处理

### DIFF
--- a/weibo.py
+++ b/weibo.py
@@ -151,10 +151,13 @@ def _http_call(the_url, method, authorization, **kw):
             raise APIError(r.error_code, r.get('error', ''), r.get('request', ''))
         return r
     except urllib2.HTTPError, e:
-        r = _parse_json(_read_body(e))
+        try:
+            r = _parse_json(_read_body(e))
+        except:
+            r = None
         if hasattr(r, 'error_code'):
             raise APIError(r.error_code, r.get('error', ''), r.get('request', ''))
-        raise
+        raise e
 
 class HttpObject(object):
 


### PR DESCRIPTION
将body转成json格式时候没有进行异常捕获，如果body不符合json格式，会抛出alueError异常。
