### PR TITLE
Follow PEP 8 - Style Guide for Python Code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,18 @@
 from distutils.core import setup
-import sys
 
 import weibo
 
-kw = dict(
-    name = 'sinaweibopy',
-    version = weibo.__version__,
-    description = 'Sina Weibo OAuth 2 API Python SDK',
-    long_description = open('README', 'r').read(),
-    author = 'Michael Liao',
-    author_email = 'askxuefeng@gmail.com',
-    url = 'https://github.com/michaelliao/sinaweibopy',
-    download_url = 'https://github.com/michaelliao/sinaweibopy',
-    py_modules = ['weibo'],
-    classifiers = [
+kw = {
+    "name": 'sinaweibopy',
+    "version": weibo.__version__,
+    "description": 'Sina Weibo OAuth 2 API Python SDK',
+    "long_description": open('README', 'r').read(),
+    "author": 'Michael Liao',
+    "author_email": 'askxuefeng@gmail.com',
+    "url": 'https://github.com/michaelliao/sinaweibopy',
+    "download_url": 'https://github.com/michaelliao/sinaweibopy',
+    "py_modules": ['weibo'],
+    "classifiers": [
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
@@ -22,6 +21,7 @@ kw = dict(
         'Programming Language :: Python',
         'Topic :: Internet',
         'Topic :: Software Development :: Libraries :: Python Modules',
-    ])
+    ]
+}
 
 setup(**kw)


### PR DESCRIPTION
PEP 8 is a style guide which is widely agreed and used in the Python
community. Follow it could encourage more Python developers to join
the development.

This commit changes the code to follow all rules of PEP 8, except
E501 - the 80 chars limitation of the each lines. For modern programs,
120 chars is more comfortable.

There are 181 violations of PEP 8 in the project:

```
$ flake8 setup.py weibo.py snspy.py | grep -v E501 | wc -l
181
```

All of the violations have been fixed:

```
$ flake8 setup.py weibo.py snspy.py | grep -v E501 | wc -l
0
```

Signed-off-by: Tom Li biergaizi@members.fsf.org
